### PR TITLE
feat(cli): add 'open' command to open items in browser

### DIFF
--- a/lib/superthread/cli/base.rb
+++ b/lib/superthread/cli/base.rb
@@ -8,6 +8,8 @@ module Superthread
     # Base class for all CLI commands.
     # Provides common options, client access, and output formatting.
     class Base < Thor
+      include Concerns::Openable
+
       def self.exit_on_failure?
         true
       end

--- a/lib/superthread/cli/boards.rb
+++ b/lib/superthread/cli/boards.rb
@@ -17,10 +17,14 @@ module Superthread
 
       desc "get BOARD", "Get board details"
       option :space, type: :string, aliases: "-s", desc: "Space (ID or name) - helps resolve board by name"
+      option :open, type: :boolean, aliases: "-o", desc: "Open in web browser"
       def get(board_ref)
         handle_error do
-          board = client.boards.find(workspace_id, resolve_board(board_ref))
+          resolved_board_id = resolve_board(board_ref)
+          board = client.boards.find(workspace_id, resolved_board_id)
           output_item board, fields: %i[id title description space_id time_created time_updated]
+
+          open_in_browser(:board, resolved_board_id)
         end
       end
 

--- a/lib/superthread/cli/cards.rb
+++ b/lib/superthread/cli/cards.rb
@@ -30,6 +30,7 @@ module Superthread
       desc "get CARD_ID", "Get card details"
       option :raw, type: :boolean, desc: "Show raw content without markdown rendering"
       option :no_content, type: :boolean, desc: "Hide content, show only metadata"
+      option :open, type: :boolean, aliases: "-o", desc: "Open in web browser"
       def get(card_id)
         handle_error do
           card = client.cards.find(workspace_id, card_id)
@@ -57,6 +58,8 @@ module Superthread
               end
             end
           end
+
+          open_in_browser(:card, card_id)
         end
       end
 

--- a/lib/superthread/cli/comments.rb
+++ b/lib/superthread/cli/comments.rb
@@ -5,9 +5,21 @@ module Superthread
     # CLI commands for comment operations.
     class Comments < Base
       desc "get COMMENT_ID", "Get comment details"
+      option :open, type: :boolean, aliases: "-o", desc: "Open in web browser"
       def get(comment_id)
-        comment = client.comments.find(workspace_id, comment_id)
-        output_item comment, fields: %i[id content user_id card_id time_created time_updated]
+        handle_error do
+          comment = client.comments.find(workspace_id, comment_id)
+          output_item comment, fields: %i[id content user_id card_id time_created time_updated]
+
+          # For comments, open the parent card if available
+          if options[:open]
+            if comment.card_id
+              open_in_browser(:card, comment.card_id)
+            else
+              Ui.warning "Cannot open comment in browser (no associated card)"
+            end
+          end
+        end
       end
 
       desc "create", "Create a comment"

--- a/lib/superthread/cli/concerns/openable.rb
+++ b/lib/superthread/cli/concerns/openable.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Superthread
+  module Cli
+    module Concerns
+      # Provides browser opening functionality for CLI commands.
+      # Include this concern and call open_in_browser after displaying an item.
+      module Openable
+        WEB_BASE_URL = "https://app.superthread.com"
+
+        # Open an item in the browser if --open flag is set.
+        #
+        # @param item_type [Symbol, String] Item type (card, board, project, etc.)
+        # @param item_id [String] Item ID
+        def open_in_browser(item_type, item_id)
+          return unless options[:open]
+
+          url = "#{WEB_BASE_URL}/#{workspace_id}/#{item_type}s/#{item_id}"
+          browser_open(url)
+          Ui.muted "Opened in browser: #{url}"
+        end
+
+        private
+
+        # Open a URL in the default browser.
+        # Cross-platform: macOS (open), Linux (xdg-open), Windows (start).
+        def browser_open(url)
+          command = case RUBY_PLATFORM
+          when /darwin/i
+            "open"
+          when /linux|bsd/i
+            "xdg-open"
+          when /mswin|mingw|cygwin/i
+            "start"
+          else
+            "open"
+          end
+
+          system(command, url)
+        end
+      end
+    end
+  end
+end

--- a/lib/superthread/cli/notes.rb
+++ b/lib/superthread/cli/notes.rb
@@ -11,9 +11,14 @@ module Superthread
       end
 
       desc "get NOTE_ID", "Get note details"
+      option :open, type: :boolean, aliases: "-o", desc: "Open in web browser"
       def get(note_id)
-        note = client.notes.find(workspace_id, note_id)
-        output_item note, fields: %i[id title content time_created time_updated]
+        handle_error do
+          note = client.notes.find(workspace_id, note_id)
+          output_item note, fields: %i[id title content time_created time_updated]
+
+          open_in_browser(:note, note_id)
+        end
       end
 
       desc "create", "Create a new note"

--- a/lib/superthread/cli/pages.rb
+++ b/lib/superthread/cli/pages.rb
@@ -16,9 +16,14 @@ module Superthread
       end
 
       desc "get PAGE_ID", "Get page details"
+      option :open, type: :boolean, aliases: "-o", desc: "Open in web browser"
       def get(page_id)
-        page = client.pages.find(workspace_id, page_id)
-        output_item page, fields: %i[id title space_id time_created time_updated]
+        handle_error do
+          page = client.pages.find(workspace_id, page_id)
+          output_item page, fields: %i[id title space_id time_created time_updated]
+
+          open_in_browser(:page, page_id)
+        end
       end
 
       desc "create", "Create a new page"

--- a/lib/superthread/cli/projects.rb
+++ b/lib/superthread/cli/projects.rb
@@ -11,9 +11,14 @@ module Superthread
       end
 
       desc "get PROJECT_ID", "Get project details"
+      option :open, type: :boolean, aliases: "-o", desc: "Open in web browser"
       def get(project_id)
-        project = client.projects.find(workspace_id, project_id)
-        output_item project, fields: %i[id title status start_date due_date time_created time_updated]
+        handle_error do
+          project = client.projects.find(workspace_id, project_id)
+          output_item project, fields: %i[id title status start_date due_date time_created time_updated]
+
+          open_in_browser(:project, project_id)
+        end
       end
 
       desc "create", "Create a new project"

--- a/lib/superthread/cli/spaces.rb
+++ b/lib/superthread/cli/spaces.rb
@@ -11,9 +11,15 @@ module Superthread
       end
 
       desc "get SPACE", "Get space details"
+      option :open, type: :boolean, aliases: "-o", desc: "Open in web browser"
       def get(space_ref)
-        space = client.spaces.find(workspace_id, resolve_space(space_ref))
-        output_item space, fields: %i[id title description time_created time_updated]
+        handle_error do
+          resolved_space_id = resolve_space(space_ref)
+          space = client.spaces.find(workspace_id, resolved_space_id)
+          output_item space, fields: %i[id title description time_created time_updated]
+
+          open_in_browser(:space, resolved_space_id)
+        end
       end
 
       desc "create", "Create a new space"

--- a/lib/superthread/cli/sprints.rb
+++ b/lib/superthread/cli/sprints.rb
@@ -13,9 +13,14 @@ module Superthread
 
       desc "get SPRINT_ID", "Get sprint details"
       option :space, type: :string, required: true, aliases: "-s", desc: "Space (ID or name)"
+      option :open, type: :boolean, desc: "Open in web browser"
       def get(sprint_id)
-        sprint = client.sprints.find(workspace_id, sprint_id, space_id: space_id)
-        output_item sprint, fields: %i[id title status start_date due_date time_created time_updated]
+        handle_error do
+          sprint = client.sprints.find(workspace_id, sprint_id, space_id: space_id)
+          output_item sprint, fields: %i[id title status start_date due_date time_created time_updated]
+
+          open_in_browser(:sprint, sprint_id)
+        end
       end
     end
   end

--- a/spec/superthread/models/user_spec.rb
+++ b/spec/superthread/models/user_spec.rb
@@ -56,12 +56,12 @@ RSpec.describe Superthread::Models::User do
     end
 
     it "returns id when present" do
-      user_with_id = described_class.from_json({ "id" => "u-456", "display_name" => "Test" }.to_json)
+      user_with_id = described_class.from_json({"id" => "u-456", "display_name" => "Test"}.to_json)
       expect(user_with_id.user_identifier).to eq("u-456")
     end
 
     it "prefers id over user_id" do
-      user_with_both = described_class.from_json({ "id" => "u-456", "user_id" => "user-789" }.to_json)
+      user_with_both = described_class.from_json({"id" => "u-456", "user_id" => "user-789"}.to_json)
       expect(user_with_both.user_identifier).to eq("u-456")
     end
   end


### PR DESCRIPTION
## Summary

Closes #13

Add `-o/--open` flag to resource `get` commands to open items in the web browser.

## Usage

```bash
suth cards get card-123 --open    # Display card and open in browser
suth cards get card-123 -o        # Short form
suth boards get board-456 --open  # Works on all resources
```

## Supported resources

- cards, boards, projects, pages, notes, spaces, sprints
- comments (opens the parent card)

## Implementation

- New `BrowserOpener` module with cross-platform browser support (macOS/Linux/Windows)
- Simple `--open` flag on existing get commands - no new top-level commands

## Test plan

- [x] All 650 tests pass
- [ ] Test `suth cards get <id> --open` opens correct URL
- [ ] Verify cross-platform detection works