### PR TITLE
fix(cards): add unwrap_key to checklist item response parsing

### DIFF
--- a/lib/superthread/resources/cards.rb
+++ b/lib/superthread/resources/cards.rb
@@ -241,7 +241,7 @@ module Superthread
           title: title,
           checklist_id: checklist_id,
           checked: checked
-        }, object_class: Models::ChecklistItem)
+        }, object_class: Models::ChecklistItem, unwrap_key: :checklist_item)
       end
 
       # Updates a checklist item.
@@ -261,7 +261,7 @@ module Superthread
         item = safe_id("item_id", item_id)
 
         patch_object("/#{ws}/cards/#{card}/checklists/#{checklist}/items/#{item}",
-          body: compact_params(**params), object_class: Models::ChecklistItem)
+          body: compact_params(**params), object_class: Models::ChecklistItem, unwrap_key: :checklist_item)
       end
 
       # Deletes a checklist item.


### PR DESCRIPTION
## Summary
- Add `unwrap_key: :checklist_item` to `add_checklist_item` method
- Add `unwrap_key: :checklist_item` to `update_checklist_item` method

This fixes the issue where `cards add-item` and `cards edit-item` showed all "-" for field values because the API response wasn't being unwrapped properly.

## Test plan
- [ ] Run `suth cards add-item --card CARD --checklist CHECKLIST --title "Test"` and verify fields display correctly
- [ ] Run `suth cards edit-item --card CARD --checklist CHECKLIST --item ITEM --checked` and verify fields display

Fixes Item 9 from #18