### PR TITLE
fix(search): fix search returning no results

### DIFF
--- a/lib/superthread/cli/search.rb
+++ b/lib/superthread/cli/search.rb
@@ -15,17 +15,19 @@ module Superthread
       # @param search_term [String] the text to search for
       # @return [void]
       def query(search_term)
-        types = options[:types]&.split(",")&.map(&:strip)
-        results = client.search.query(
-          workspace_id,
-          query: search_term,
-          field: options[:field],
-          types: types,
-          space_id: space_id,
-          archived: options[:archived],
-          grouped: options[:grouped]
-        )
-        output_list results
+        handle_error do
+          types = options[:types]&.split(",")&.map(&:strip)
+          results = client.search.query(
+            workspace_id,
+            query: search_term,
+            field: options[:field],
+            types: types,
+            space_id: space_id,
+            archived: options[:archived],
+            grouped: options[:grouped]
+          )
+          output_list results, columns: %i[result_type id title]
+        end
       end
     end
   end

--- a/lib/superthread/resources/search.rb
+++ b/lib/superthread/resources/search.rb
@@ -17,13 +17,29 @@ module Superthread
       # @option params [Array<String>] :statuses status values to filter by
       # @option params [String] :space_id the space identifier to filter by
       # @option params [Boolean] :archived when true, includes archived entities
-      # @option params [Boolean] :grouped when true, groups results by type
+      # @option params [Boolean] :grouped when true, groups results by type (default: false)
       # @option params [String] :cursor the pagination cursor for next page
       # @return [Superthread::Objects::Collection] the search results
       def query(workspace_id, query:, **params)
         ws = safe_id("workspace_id", workspace_id)
-        search_params = compact_params(query: query, project_id: params[:space_id], **params.except(:space_id))
-        get_collection("/#{ws}/search", params: search_params, items_key: :results)
+        # Default grouped to false so results come in a flat array
+        # Use || instead of fetch because CLI may pass grouped: nil explicitly
+        grouped = params[:grouped].nil? ? false : params[:grouped]
+        search_params = compact_params(
+          query: query,
+          project_id: params[:space_id],
+          grouped: grouped,
+          **params.except(:space_id, :grouped)
+        )
+        response = http_get("/#{ws}/search", params: search_params)
+
+        # Unwrap results - each item is {"card": {...}} or {"board": {...}}, etc.
+        results = (response[:results] || []).map do |item|
+          result_type, data = item.first
+          data.merge(result_type: result_type.to_s)
+        end
+
+        Objects::Collection.from_response(results)
       end
     end
   end

--- a/spec/support/api_fixtures.rb
+++ b/spec/support/api_fixtures.rb
@@ -675,16 +675,21 @@ module ApiFixtures
   end
 
   module Search
+    # API returns wrapped objects when grouped=false (our default)
     RESULTS = {
+      count: 2,
+      cursor: "",
       results: [
-        {id: "card-auth", title: "Auth Module", type: "card", space_id: "1"},
-        {id: "page-login", title: "Login Flow", type: "page", space_id: "1"}
+        {card: {id: "card-auth", title: "Auth Module", board_id: "1", list_id: "1", project_id: "1"}},
+        {page: {id: "page-login", title: "Login Flow", space_id: "1"}}
       ]
     }.freeze
 
     RESULTS_TYPED = {
+      count: 1,
+      cursor: "",
       results: [
-        {id: "card-auth", title: "Auth Module", type: "card", space_id: "1"}
+        {card: {id: "card-auth", title: "Auth Module", board_id: "1", list_id: "1", project_id: "1"}}
       ]
     }.freeze
   end


### PR DESCRIPTION
## Summary
The search command was returning empty results because:
1. API defaults `grouped=true`, returning results in separate arrays (`boards`, `cards`, etc.) with `results: null`
2. Code expected `items_key: :results` which was always null

## Changes
- Default `grouped` to `false` so results come in flat `results` array
- Handle wrapped response format (`{"card": {...}}`) by unwrapping and adding `result_type`
- Update CLI to show cleaner columns: `result_type`, `id`, `title`
- Update test fixtures to match real API response format

## Test plan
- [x] `suth search query "test"` returns results with type, id, title
- [x] `suth search query "test" --json` returns full result objects
- [x] All 697 tests pass

Fixes Item 21 from #18