### PR TITLE
fix(cards): add unwrap_key to checklist response parsing

### DIFF
--- a/lib/superthread/resources/cards.rb
+++ b/lib/superthread/resources/cards.rb
@@ -221,7 +221,7 @@ module Superthread
         ws = safe_id("workspace_id", workspace_id)
         card = safe_id("card_id", card_id)
         post_object("/#{ws}/cards/#{card}/checklists", body: {title: title},
-          object_class: Models::Checklist)
+          object_class: Models::Checklist, unwrap_key: :checklist)
       end
 
       # Adds an item to a checklist.
@@ -294,7 +294,7 @@ module Superthread
         checklist = safe_id("checklist_id", checklist_id)
 
         patch_object("/#{ws}/cards/#{card}/checklists/#{checklist}", body: {title: title},
-          object_class: Models::Checklist)
+          object_class: Models::Checklist, unwrap_key: :checklist)
       end
 
       # Deletes a checklist and all its items.


### PR DESCRIPTION
## Summary
- Add `unwrap_key: :checklist` to `create_checklist` method
- Add `unwrap_key: :checklist` to `update_checklist` method

This fixes the issue where `cards add-checklist` and `cards edit-checklist` showed all "-" for field values because the API response wasn't being unwrapped properly.

## Test plan
- [ ] Run `suth cards add-checklist CARD --title "Test"` and verify fields display correctly
- [ ] Run `suth cards edit-checklist --card CARD --checklist ID --title "New"` and verify fields display

Fixes Item 8 from #18