### PR TITLE
feat: Add @mention formatting for comments and checklists #20

### DIFF
--- a/lib/superthread/mention_formatter.rb
+++ b/lib/superthread/mention_formatter.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "cgi"
+
+module Superthread
+  # Converts {{@mentions}} in content to Superthread's HTML user-mention tags.
+  #
+  # Superthread allows user names with spaces, punctuation, and titles
+  # (e.g., "John A. J. Smith the 3rd, Esq."), making traditional @mention
+  # syntax unreliable. The {{@Name}} template syntax provides unambiguous
+  # delimiters that handle any valid display name.
+  #
+  # Uses a three-pass algorithm:
+  # 1. Escape protected mentions: `\{{@Name}}` -> placeholder
+  # 2. Replace mentions: `{{@Name}}` -> `<user-mention>` HTML tag
+  # 3. Restore escaped text: placeholder -> `{{@Name}}`
+  #
+  # @example Basic usage
+  #   formatter = MentionFormatter.new(client, "ws-123")
+  #   formatter.format("Hey {{@Steve Clarke}}, check this")
+  #   # => 'Hey <user-mention data-type="mention" user-id="u123" ...></user-mention>, check this'
+  #
+  # @example Escaping
+  #   formatter.format('Use \{{@Username}} syntax to mention users')
+  #   # => "Use {{@Username}} syntax to mention users"
+  class MentionFormatter
+    # @return [Regexp] pattern matching `{{@Name}}` mention templates
+    MENTION_PATTERN = /\{\{@([^}]+)\}\}/
+    # @return [Regexp] pattern matching escaped `\{{@Name}}` mentions
+    ESCAPE_PATTERN = /\\\{\{@([^}]+)\}\}/
+    # @return [Regexp] pattern matching placeholders used during escape processing
+    PLACEHOLDER_PATTERN = /___ESCAPED_MENTION_(.+?)___END___/
+
+    # @param client [Superthread::Client] the API client for fetching members
+    # @param workspace_id [String] the workspace to look up members in
+    def initialize(client, workspace_id)
+      @client = client
+      @workspace_id = workspace_id
+    end
+
+    # Formats mention templates in content to HTML user-mention tags.
+    #
+    # @param content [String, nil] text that may contain {{@Name}} patterns
+    # @return [String, nil] content with mentions converted to HTML tags
+    def format(content)
+      return content if content.nil? || !content.include?("{{@")
+
+      member_map = build_member_map
+      return content if member_map.nil?
+
+      mention_time = Time.now.to_i
+
+      # Pass 1: protect escaped mentions (store name only, not the {{@ }} delimiters)
+      result = content.gsub(ESCAPE_PATTERN, '___ESCAPED_MENTION_\1___END___')
+
+      # Pass 2: replace {{@Name}} with HTML tags
+      result = result.gsub(MENTION_PATTERN) do |match|
+        name = Regexp.last_match(1).strip
+        member = member_map[name.downcase]
+
+        if member
+          safe_id = CGI.escapeHTML(member[:id])
+          safe_name = CGI.escapeHTML(member[:name])
+          '<user-mention data-type="mention" ' \
+            "user-id=\"#{safe_id}\" " \
+            "mention-time=\"#{mention_time}\" " \
+            "user-value=\"#{safe_name}\" " \
+            'denotation-char="@"></user-mention>'
+        else
+          match
+        end
+      end
+
+      # Pass 3: restore escaped mentions as literal {{@Name}} text
+      result.gsub(PLACEHOLDER_PATTERN, '{{@\1}}')
+    end
+
+    private
+
+    # Fetches workspace members and builds a case-insensitive lookup map.
+    #
+    # @return [Hash{String => Hash}, nil] map of lowercase names to {id:, name:}, or nil on failure
+    def build_member_map
+      members = @client.users.members(@workspace_id)
+      map = {}
+      members.each do |member|
+        next unless member.display_name
+
+        map[member.display_name.downcase] = {
+          id: member.user_identifier,
+          name: member.display_name
+        }
+      end
+      map
+    rescue Superthread::Error
+      nil
+    end
+  end
+end

--- a/lib/superthread/resources/base.rb
+++ b/lib/superthread/resources/base.rb
@@ -172,6 +172,17 @@ module Superthread
         args.compact
       end
 
+      # Formats {{@mentions}} in content to HTML user-mention tags.
+      #
+      # @param workspace_id [String] the workspace identifier for member lookup
+      # @param content [String, nil] text that may contain {{@Name}} patterns
+      # @return [String, nil] content with mentions converted to HTML tags
+      def format_mentions(workspace_id, content)
+        return content if content.nil?
+
+        MentionFormatter.new(@client, workspace_id).format(content)
+      end
+
       # Builds an API path prefixed with the workspace ID.
       #
       # @param workspace_id [String] the workspace identifier

--- a/lib/superthread/resources/cards.rb
+++ b/lib/superthread/resources/cards.rb
@@ -238,6 +238,7 @@ module Superthread
         ws = safe_id("workspace_id", workspace_id)
         card = safe_id("card_id", card_id)
         checklist = safe_id("checklist_id", checklist_id)
+        title = format_mentions(workspace_id, title)
 
         post_object("/#{ws}/cards/#{card}/checklists/#{checklist}/items", body: {
           title: title,
@@ -261,6 +262,7 @@ module Superthread
         card = safe_id("card_id", card_id)
         checklist = safe_id("checklist_id", checklist_id)
         item = safe_id("item_id", item_id)
+        params[:title] = format_mentions(workspace_id, params[:title]) if params[:title]
 
         patch_object("/#{ws}/cards/#{card}/checklists/#{checklist}/items/#{item}",
           body: compact_params(**params), object_class: Models::ChecklistItem, unwrap_key: :checklist_item)

--- a/lib/superthread/resources/comments.rb
+++ b/lib/superthread/resources/comments.rb
@@ -31,6 +31,7 @@ module Superthread
       # @return [Superthread::Models::Comment] the created comment
       def create(workspace_id, content:, card_id: nil, page_id: nil, **params)
         ws = safe_id("workspace_id", workspace_id)
+        content = format_mentions(workspace_id, content)
         body = compact_params(content: content, card_id: card_id, page_id: page_id, **params)
         post_object("/#{ws}/comments", body: body,
           object_class: Models::Comment, unwrap_key: :comment)
@@ -61,6 +62,7 @@ module Superthread
       def update(workspace_id, comment_id, **params)
         ws = safe_id("workspace_id", workspace_id)
         comment = safe_id("comment_id", comment_id)
+        params[:content] = format_mentions(workspace_id, params[:content]) if params[:content]
         patch_object("/#{ws}/comments/#{comment}", body: compact_params(**params),
           object_class: Models::Comment, unwrap_key: :comment)
       end
@@ -88,6 +90,7 @@ module Superthread
       def reply(workspace_id, comment_id, content:, **params)
         ws = safe_id("workspace_id", workspace_id)
         comment = safe_id("comment_id", comment_id)
+        content = format_mentions(workspace_id, content)
         body = compact_params(content: content, **params)
         post_object("/#{ws}/comments/#{comment}/children", body: body,
           object_class: Models::Comment, unwrap_key: :comment)
@@ -118,6 +121,7 @@ module Superthread
         ws = safe_id("workspace_id", workspace_id)
         comment = safe_id("comment_id", comment_id)
         reply = safe_id("reply_id", reply_id)
+        params[:content] = format_mentions(workspace_id, params[:content]) if params[:content]
         patch_object("/#{ws}/comments/#{comment}/children/#{reply}", body: compact_params(**params),
           object_class: Models::Comment, unwrap_key: :comment)
       end

--- a/spec/superthread/mention_formatter_spec.rb
+++ b/spec/superthread/mention_formatter_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+RSpec.describe Superthread::MentionFormatter do
+  let(:workspace_id) { "ws-123" }
+  let(:client) { instance_double(Superthread::Client) }
+  let(:users_resource) { instance_double(Superthread::Resources::Users) }
+
+  let(:members) do
+    [
+      instance_double(Superthread::Models::User,
+        display_name: "Steve Clarke",
+        user_identifier: "u-steve"),
+      instance_double(Superthread::Models::User,
+        display_name: "John Smith",
+        user_identifier: "u-john")
+    ]
+  end
+
+  before do
+    allow(client).to receive(:users).and_return(users_resource)
+    allow(users_resource).to receive(:members).with(workspace_id).and_return(members)
+  end
+
+  subject(:formatter) { described_class.new(client, workspace_id) }
+
+  describe "#format" do
+    it "converts a single mention to a user-mention tag" do
+      result = formatter.format("Hey {{@Steve Clarke}}, check this")
+
+      expect(result).to include('user-id="u-steve"')
+      expect(result).to include('user-value="Steve Clarke"')
+      expect(result).to include('data-type="mention"')
+      expect(result).to include('denotation-char="@"')
+      expect(result).to include("mention-time=")
+      expect(result).not_to include("{{@Steve Clarke}}")
+    end
+
+    it "converts multiple mentions in one string" do
+      result = formatter.format("{{@Steve Clarke}} and {{@John Smith}} should review this")
+
+      expect(result).to include('user-id="u-steve"')
+      expect(result).to include('user-id="u-john"')
+      expect(result).not_to include("{{@")
+    end
+
+    it "matches names case-insensitively" do
+      result = formatter.format("Hey {{@steve clarke}}")
+
+      expect(result).to include('user-id="u-steve"')
+      expect(result).to include('user-value="Steve Clarke"')
+    end
+
+    it "preserves original casing in the user-value attribute" do
+      result = formatter.format("{{@STEVE CLARKE}}")
+
+      expect(result).to include('user-value="Steve Clarke"')
+    end
+
+    it "leaves unmatched names as-is" do
+      result = formatter.format("Hey {{@Unknown Person}}")
+
+      expect(result).to eq("Hey {{@Unknown Person}}")
+    end
+
+    it "handles a mix of matched and unmatched mentions" do
+      result = formatter.format("{{@Steve Clarke}} and {{@Nobody}}")
+
+      expect(result).to include('user-id="u-steve"')
+      expect(result).to include("{{@Nobody}}")
+    end
+
+    it "preserves escaped mentions as literal text" do
+      result = formatter.format('Use \{{@Steve Clarke}} syntax to mention users')
+
+      expect(result).to eq("Use {{@Steve Clarke}} syntax to mention users")
+      expect(result).not_to include("user-mention")
+    end
+
+    it "handles escaped and real mentions in the same string" do
+      result = formatter.format('Say \{{@Steve Clarke}} to tag {{@Steve Clarke}}')
+
+      expect(result).to include("{{@Steve Clarke}}")
+      expect(result).to include('user-id="u-steve"')
+    end
+
+    it "returns nil for nil content" do
+      expect(formatter.format(nil)).to be_nil
+    end
+
+    it "returns content as-is when no mention pattern is present" do
+      content = "Just a regular comment"
+      result = formatter.format(content)
+
+      expect(result).to eq(content)
+      expect(users_resource).not_to have_received(:members)
+    end
+
+    it "returns content as-is when member fetch fails" do
+      allow(users_resource).to receive(:members).and_raise(Superthread::ApiError.new("fail"))
+
+      result = formatter.format("Hey {{@Steve Clarke}}")
+
+      expect(result).to eq("Hey {{@Steve Clarke}}")
+    end
+
+    it "trims whitespace in mention names" do
+      result = formatter.format("Hey {{@ Steve Clarke }}")
+
+      expect(result).to include('user-id="u-steve"')
+    end
+
+    it "HTML-escapes attribute values for XSS defense" do
+      evil_members = [
+        instance_double(Superthread::Models::User,
+          display_name: 'Evil "User',
+          user_identifier: 'u-"><script>')
+      ]
+      allow(users_resource).to receive(:members).and_return(evil_members)
+
+      result = formatter.format('Hey {{@Evil "User}}')
+
+      expect(result).to include("u-&quot;&gt;&lt;script&gt;")
+      expect(result).to include("Evil &quot;User")
+      expect(result).not_to include("<script>")
+    end
+
+    it "includes a valid Unix timestamp in mention-time" do
+      freeze_time = Time.now
+      allow(Time).to receive(:now).and_return(freeze_time)
+
+      result = formatter.format("{{@Steve Clarke}}")
+
+      expect(result).to include("mention-time=\"#{freeze_time.to_i}\"")
+    end
+
+    it "skips members with nil display_name" do
+      members_with_nil = [
+        instance_double(Superthread::Models::User,
+          display_name: nil,
+          user_identifier: "u-ghost"),
+        instance_double(Superthread::Models::User,
+          display_name: "Steve Clarke",
+          user_identifier: "u-steve")
+      ]
+      allow(users_resource).to receive(:members).and_return(members_with_nil)
+
+      result = formatter.format("{{@Steve Clarke}}")
+      expect(result).to include('user-id="u-steve"')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `MentionFormatter` class that converts `{{@Username}}` syntax to Superthread's `<user-mention>` HTML tags
- Integrates at the resource layer so both CLI and library consumers get automatic mention support
- Applies to comments (create/update), replies (create/update), and checklist items (add/update)

Ports the existing implementation from the TypeScript MCP server (`mcp-superthread-plus/src/utils.ts`).

Closes #20

## Details

- Three-pass algorithm: escape protected mentions, replace matches, restore escaped text
- Case-insensitive name matching against workspace members
- HTML-escapes attribute values for XSS defense
- Graceful degradation: returns content unchanged if member fetch fails
- Unmatched names stay as literal `{{@Name}}` text

## Test plan

- [x] 15 unit tests covering all behaviors (match, no match, escaping, XSS, error handling)
- [x] Full suite passes (724 examples, 0 failures)
- [x] StandardRB clean
- [x] YARD docs clean
- [x] Manual verification: created a comment with `{{@Steve Clarke}}` on MCP Testing board, confirmed `<user-mention>` tag in API response