### PR TITLE
fix: Fix replies response parsing and lookup #31

### DIFF
--- a/lib/superthread/cli/replies.rb
+++ b/lib/superthread/cli/replies.rb
@@ -20,13 +20,18 @@ module Superthread
       end
 
       desc "get REPLY_ID", "Get reply details"
+      option :comment, type: :string, required: true, desc: "Parent comment ID"
       # Display detailed information about a specific reply.
       #
       # @param reply_id [String] the unique identifier of the reply
       # @return [void]
       def get(reply_id)
         handle_error do
-          reply = client.comments.find(workspace_id, reply_id)
+          begin
+            reply = client.comments.find_reply(workspace_id, options[:comment], reply_id)
+          rescue Superthread::NotFoundError
+            raise Thor::Error, "Reply not found: '#{reply_id}' on comment '#{options[:comment]}'."
+          end
           output_item reply, fields: %i[id content user_id card_id time_created time_updated], labels: {
             id: "Reply ID",
             user_id: "User ID",
@@ -76,7 +81,7 @@ module Superthread
       # @return [void]
       def delete(reply_id)
         handle_error do
-          reply = client.comments.find(workspace_id, reply_id)
+          reply = client.comments.find_reply(workspace_id, options[:comment], reply_id)
           # Strip HTML and normalize whitespace for preview
           plain = reply.content.to_s.gsub(/<[^>]+>/, " ").gsub(/\s+/, " ").strip
           preview = Formatter.truncate(plain, 50)

--- a/lib/superthread/resources/comments.rb
+++ b/lib/superthread/resources/comments.rb
@@ -93,7 +93,7 @@ module Superthread
         content = format_mentions(workspace_id, content)
         body = compact_params(content: content, **params)
         post_object("/#{ws}/comments/#{comment}/children", body: body,
-          object_class: Models::Comment, unwrap_key: :comment)
+          object_class: Models::Comment, unwrap_key: :child_comment)
       end
 
       # Gets replies to a comment.
@@ -106,6 +106,25 @@ module Superthread
         comment = safe_id("comment_id", comment_id)
         get_collection("/#{ws}/comments/#{comment}/children",
           item_class: Models::Comment, items_key: :child_comments)
+      end
+
+      # Gets a specific reply by listing all replies on the parent comment
+      # and finding the matching one.
+      #
+      # @param workspace_id [String] the workspace identifier
+      # @param comment_id [String] the parent comment identifier
+      # @param reply_id [String] the reply identifier to find
+      # @return [Superthread::Models::Comment] the reply
+      # @raise [Superthread::NotFoundError] if the reply is not found
+      def find_reply(workspace_id, comment_id, reply_id)
+        all_replies = replies(workspace_id, comment_id)
+        found = all_replies.find { |r| r.id == reply_id }
+        unless found
+          raise Superthread::NotFoundError.new(
+            "Reply '#{reply_id}' not found on comment '#{comment_id}'"
+          )
+        end
+        found
       end
 
       # Updates a reply's attributes.
@@ -123,7 +142,7 @@ module Superthread
         reply = safe_id("reply_id", reply_id)
         params[:content] = format_mentions(workspace_id, params[:content]) if params[:content]
         patch_object("/#{ws}/comments/#{comment}/children/#{reply}", body: compact_params(**params),
-          object_class: Models::Comment, unwrap_key: :comment)
+          object_class: Models::Comment, unwrap_key: :child_comment)
       end
 
       # Deletes a reply permanently.

--- a/spec/integration/cli/replies_spec.rb
+++ b/spec/integration/cli/replies_spec.rb
@@ -30,24 +30,24 @@ RSpec.describe "st replies", :cli do
     end
   end
 
-  describe "replies get REPLY_ID" do
+  describe "replies get REPLY_ID --comment" do
     before do
-      stub_api_get("test_workspace/comments/reply-1", response: ApiFixtures::Comments::REPLY_CREATE)
+      stub_api_get("test_workspace/comments/comment-1/children", response: ApiFixtures::Comments::REPLIES)
     end
 
     it "displays reply details" do
-      result = run_cli("replies", "get", "reply-1")
+      result = run_cli("replies", "get", "reply-1", "--comment=comment-1")
 
       expect(result[:exit_code]).to eq(0)
       expect(result[:stdout]).to include("reply-1")
-      expect(result[:stdout]).to include("This is a reply")
+      expect(result[:stdout]).to include("Reply 1")
     end
 
     it "outputs JSON with --json flag" do
-      json = cli_json("replies", "get", "reply-1")
+      json = cli_json("replies", "get", "reply-1", "--comment=comment-1")
 
       expect(json["id"]).to eq("reply-1")
-      expect(json["content"]).to include("This is a reply")
+      expect(json["content"]).to include("Reply 1")
     end
   end
 
@@ -94,7 +94,8 @@ RSpec.describe "st replies", :cli do
 
   describe "replies delete REPLY_ID" do
     before do
-      stub_api_get("test_workspace/comments/reply-to-delete", response: ApiFixtures::Comments::REPLY_DELETE)
+      stub_api_get("test_workspace/comments/comment-1/children",
+        response: ApiFixtures::Comments::REPLIES_WITH_DELETE_TARGET)
       stub_api_delete("test_workspace/comments/comment-1/children/reply-to-delete")
     end
 

--- a/spec/support/api_fixtures.rb
+++ b/spec/support/api_fixtures.rb
@@ -513,7 +513,7 @@ module ApiFixtures
     }.freeze
 
     REPLY_CREATE = {
-      comment: {
+      child_comment: {
         id: "reply-1",
         content: "<p>This is a reply</p>",
         user_id: "user-1",
@@ -522,7 +522,7 @@ module ApiFixtures
     }.freeze
 
     REPLY_UPDATE = {
-      comment: {
+      child_comment: {
         id: "reply-1",
         content: "<p>Updated reply</p>",
         user_id: "user-1",
@@ -542,14 +542,11 @@ module ApiFixtures
       }
     }.freeze
 
-    # Used for delete_reply confirmation
-    REPLY_DELETE = {
-      comment: {
-        id: "reply-to-delete",
-        content: "<p>Reply to delete</p>",
-        user_id: "user-1",
-        time_created: 1705312200000
-      }
+    # Used for find_reply lookup in delete confirmation
+    REPLIES_WITH_DELETE_TARGET = {
+      child_comments: [
+        {id: "reply-to-delete", content: "<p>Reply to delete</p>", user_id: "user-1", time_created: 1705312200000}
+      ]
     }.freeze
   end
 


### PR DESCRIPTION
## Summary

- Fix `unwrap_key` for reply create/update (API returns `{child_comment: {...}}` not `{comment: {...}}`)
- Add `find_reply()` resource method that lists replies and finds by ID (no single-reply API endpoint exists)
- Fix `replies get` to use `find_reply()` with required `--comment` option instead of `comments.find()`
- Fix `replies delete` to use `find_reply()` for the confirmation preview lookup

Closes #31

## Test plan

- [x] All 9 replies specs pass with corrected stubs and fixtures
- [x] Full suite passes (724 examples, 0 failures)
- [x] StandardRB clean
- [x] YARD docs clean
- [x] Manual: `replies create` now shows fields instead of "-"
- [x] Manual: `replies get REPLY_ID --comment ID` returns reply details